### PR TITLE
Fix 404s - expects empty list returned; also implement "list" method.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,2 +1,3 @@
 v0.1, 2014-06-05 -- Initial release.
 v0.1.1, 2014-10-20 -- Fix module name in README.rst. Better error reporting.
+v0.3.0, 2016-04-08 -- Improve file finding so we get proper 404s and the list method works.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
 v0.1, 2014-06-05 -- Initial release.
 v0.1.1, 2014-10-20 -- Fix module name in README.rst. Better error reporting.
 v0.3.0, 2016-04-08 -- Improve file finding so we get proper 404s and the list method works.
+v0.3.1, 2016-04-08 -- Oops we can't implement list(), it breaks things

--- a/django_static_root_finder/finders.py
+++ b/django_static_root_finder/finders.py
@@ -31,9 +31,6 @@ class StaticRootFinder(BaseFinder):
             return []
 
     def list(self, ignore_patterns):
-        static_root = getattr(settings, 'STATIC_ROOT', '')
-        storage = FileSystemStorage(location=static_root)
-
-        for path in utils.get_files(storage, ignore_patterns):
-            yield path, storage
+        # List isn't implemented - we can't collect static
+        return []
 

--- a/django_static_root_finder/finders.py
+++ b/django_static_root_finder/finders.py
@@ -27,7 +27,13 @@ class StaticRootFinder(BaseFinder):
 
         if path.isfile(static_root_file_path):
             return static_root_file_path
+        else:
+            return []
 
     def list(self, ignore_patterns):
-        # Do nothing for collectstatic
-        return []
+        static_root = getattr(settings, 'STATIC_ROOT', '')
+        storage = FileSystemStorage(location=static_root)
+
+        for path in utils.get_files(storage, ignore_patterns):
+            yield path, storage
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-static-root-finder',
-    version='0.3.0',
+    version='0.3.1',
     author='Robin',
     author_email='robin.winslow@canonical.com',
     url='https://github.com/ubuntudesign/django-static-root-finder',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-static-root-finder',
-    version='0.1.1',
+    version='0.3.0',
     author='Robin',
     author_email='robin.winslow@canonical.com',
     url='https://github.com/ubuntudesign/django-static-root-finder',


### PR DESCRIPTION
## QA

Visit any `static/{something}` URL which doesn't exist, check you get a 404
